### PR TITLE
Add initial Textual app scaffold

### DIFF
--- a/docs/design_workflow.md
+++ b/docs/design_workflow.md
@@ -1,0 +1,61 @@
+# Streamline Aircraft Design Workflow Vision
+
+This document outlines a target end-to-end experience for aerospace designers using Streamline with the `AnalysisManager` orchestration pattern and OpenVSP as the primary geometry backbone. The goal is to provide a consistent mental model for how the Textual app should evolve so that the tooling accelerates concept development, detailed design, and optimization.
+
+## 1. Concept Framing & Project Setup
+- **Design brief intake:** Prompt for mission requirements (payload, range, speed, field length, noise regulations) and certification basis. Capture the rationale as project metadata.
+- **Reference library access:** Surface curated catalogs of baseline missions, propulsion architectures, configurations, and technology assumptions already supported by the repository. Enable quick cloning of a reference design to seed a new project.
+- **Requirement envelopes:** Provide widgets to translate high-level targets into derived constraints (wing loading, thrust-to-weight bands, cabin volume) that can be stored alongside the project definition.
+- **Collaboration hooks:** Track authorship, design stage, and review notes within the project manifest so teams can coordinate edits and analysis runs.
+
+## 2. Geometry Authoring with OpenVSP
+- **Component palette:** Expose OpenVSP primitives (wings, bodies, pods, nacelles, propellers) with presets matching common aircraft categories (GA, eVTOL, MALE UAV, regional jet). Allow insertion, cloning, and hierarchy editing directly from the TUI.
+- **Parametric editing:** Map OpenVSP parameters (span, sweep, twist, airfoil selections) to Streamline `EditBatch` operations so designers can adjust geometry numerically or via sliders. Provide constraint-aware editing that respects symmetry, continuity, and configuration-specific rules.
+- **Visualization cues:** While the TUI is text-first, integrate quick previews (ASCII summary tables, sparkline plots) and allow launching the full OpenVSP GUI with the current project model for detailed inspection.
+- **Geometry validation:** Automate checks for watertightness, component intersections, and control surface linkage completeness using existing OpenVSP diagnostics. Report issues via the notification center with actionable fixes.
+
+## 3. Configuration & Catalog Management
+- **Structured edits:** Use `StagedEditBatch` flows so users can queue multiple geometry and configuration tweaks before committing, with diffs previewed against the current catalog entries.
+- **Variant tracking:** Support branching configurations (baseline, stretch, freighter) using the results index to tag receipts and artifacts, ensuring analyses stay associated with the correct variant.
+- **Payload & interior planning:** Provide forms to manage cabin layouts, payload bay dimensions, and CG envelopes, leveraging existing schema modules for mass properties.
+
+## 4. Aerodynamic Analysis Pipeline
+- **Quick-look analyses:** One-click submissions for parasite drag builds, lifting-line approximations, and stability/trim sweeps using OpenVSP’s VSPAero and MassProp back-ends orchestrated by the `AnalysisManager`.
+- **Job orchestration:** Display real-time job queues, worker status, and cached receipts. Allow reruns with cache invalidation when geometry changes invalidate previous results.
+- **Result visualization:** Summaries for polars, stability derivatives, and control deflection requirements. Provide export options to CSV/JSON for post-processing.
+
+## 5. Propulsion & Powertrain Integration
+- **Architecture templates:** Wizards for selecting turbofan, turboprop, piston, hybrid-electric, or distributed propulsion setups. Tie into propulsion catalogs already defined in the repository.
+- **Sizing loops:** Automate iteration between propulsion sizing (thrust/power curves) and mission analysis, using the `AnalysisManager` to coordinate dependencies.
+- **Performance maps:** Display power lapse, SFC tables, and throttle schedules, with hooks to update mission segments.
+
+## 6. Weights, Balance, and Structures
+- **Mass estimation:** Integrate empirical weight models and OpenVSP MassProp outputs. Allow component-level overrides and sensitivity tracking.
+- **CG management:** Visualize loading diagrams and ensure mission fuel burn keeps CG within limits. Provide trim margin checks tied to stability analyses.
+- **Structural checks:** Connect to finite-beam approximations or external FEA hooks for wing/boom sizing, exposing placeholder adapters for future solvers.
+
+## 7. Mission Simulation & Performance Evaluation
+- **Mission builder:** Drag-and-drop (or command-driven) assembly of mission segments with climb, cruise, loiter, and reserve logic. Support branching scenarios for different payloads or environmental conditions.
+- **Performance dashboards:** Present key results—payload-range diagrams, field performance, climb gradients—aggregated from cached analysis receipts.
+- **Certification views:** Map results to FAR/CS compliance checklists, flagging items needing additional substantiation.
+
+## 8. Optimization & Trade Studies
+- **Design variables:** Allow tagging of OpenVSP parameters, mission settings, and propulsion knobs as optimization variables with bounds and step sizes.
+- **Objective/constraint management:** Provide a catalog of common objectives (fuel burn, DOC, takeoff distance) and constraints, with the ability to assemble multi-objective studies.
+- **Optimization drivers:** Start with DOE/parameter sweeps orchestrated via `AnalysisManager` ticket batches, and plan for integration with gradient-free optimizers (e.g., NLopt, pyOptSparse) as external workers.
+- **Trade study tracking:** Store each optimization or sweep as a manifest entry with metadata, making it easy to revisit, compare, and export results.
+
+## 9. User Experience & Automation Layers
+- **Session dashboard:** Central hub summarizing project state, recent edits, queued analyses, and outstanding issues.
+- **Guided workflows:** Task-based checklists that walk designers from requirements capture through preliminary design, ensuring critical analyses are run before major decisions.
+- **Scripting hooks:** Expose a lightweight command language (or Python REPL) within the TUI for power users to script edits and analyses.
+- **Notification & logging:** Channel all errors, warnings, and success messages through a consistent UI element, using `StreamlineError` metadata to provide context.
+
+## 10. Future Integrations
+- **External toolchain bridges:** Plan adapters for CFD (SU2, OpenFOAM), structural solvers, and cost models, keeping the `AnalysisManager` interface consistent.
+- **Cloud/offload support:** Allow analyses to dispatch to remote workers or cloud instances, tracking provenance in the receipts.
+- **Team collaboration:** Integrate version control awareness (Git hooks) and shared project repositories with permissions and review workflows.
+
+---
+
+This vision keeps Streamline’s existing modular patterns front and center—project manifests, catalog-driven configuration, and the `AnalysisManager` execution engine—while extending the Textual interface into a comprehensive aircraft design cockpit. It should guide prioritization of upcoming development tasks and highlight where OpenVSP’s strengths (rapid geometry changes, embedded analysis tools) can be leveraged most effectively.

--- a/streamline/main.py
+++ b/streamline/main.py
@@ -29,6 +29,7 @@ from .io.config_catalog import load_config_catalog
 from .io.fs import load_config, load_project_def, write_json
 from .io.op_catalog import get_operating_point, load_op_catalog
 from .io.results_index import load_result_entries
+from .tui import StreamlineApp
 from .vsp.contracts import ComputeGeometryTicket, ParasiteDragTicket, StabilityTicket
 from .vsp.configure import apply_configuration
 from .vsp.operating_point import apply_operating_point
@@ -592,6 +593,18 @@ def main(argv: Optional[list[str]] = None) -> int:
     p_smoke.add_argument("--mach", type=float, default=None, help="Override Mach number if desired")
     p_smoke.add_argument("--alpha-deg", type=float, default=None, help="Angle of attack override (deg)")
 
+    p_tui = sub.add_parser("tui", help="Launch the Textual interface")
+    p_tui.add_argument(
+        "--projects-root",
+        default=str(repo_root_from_here() / "projects"),
+        help="Root folder for projects/ (default: ./projects)",
+    )
+    p_tui.add_argument(
+        "--open-gui",
+        action="store_true",
+        help="Open OpenVSP GUI when the analysis manager is first created",
+    )
+
     args = parser.parse_args(argv)
 
     log_file = Path(args.log_file).expanduser().resolve() if args.log_file else None
@@ -740,6 +753,12 @@ def main(argv: Optional[list[str]] = None) -> int:
                 config_id=args.config_id,
                 op_id=args.op_id,
             )
+            return 0
+
+        if args.cmd == "tui":
+            projects_root = ensure_dir(Path(args.projects_root))
+            app = StreamlineApp(projects_root=projects_root, open_gui=args.open_gui)
+            app.run()
             return 0
 
         return 0

--- a/streamline/tui/__init__.py
+++ b/streamline/tui/__init__.py
@@ -1,0 +1,5 @@
+"""Textual user interface scaffolding for Streamline."""
+
+from .app import StreamlineApp
+
+__all__ = ["StreamlineApp"]

--- a/streamline/tui/app.py
+++ b/streamline/tui/app.py
@@ -1,0 +1,85 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Optional
+
+from textual import events
+from textual.app import App, ComposeResult
+from textual.binding import Binding
+from textual.widgets import Footer, Header, ListView
+
+from ..core import get_logger
+from .session import ProjectSummary, StreamlineSession
+from .widgets import AnalysisQueueView, PrimaryLayout, ProjectList, ProjectSummaryView
+
+
+def _default_projects_root() -> Path:
+    return Path(__file__).resolve().parents[2] / "projects"
+
+
+class StreamlineApp(App[None]):
+    """First-pass Textual interface for Streamline."""
+
+    CSS_PATH = Path(__file__).with_name("app.tcss")
+    BINDINGS = [
+        Binding("q", "quit", "Quit"),
+        Binding("r", "refresh_projects", "Refresh"),
+    ]
+
+    def __init__(self, projects_root: Optional[Path] = None, *, open_gui: bool = False) -> None:
+        super().__init__()
+        root = Path(projects_root) if projects_root is not None else _default_projects_root()
+        self.session = StreamlineSession(root, open_gui=open_gui)
+        self.logger = get_logger(__name__)
+        self._active_project: Optional[ProjectSummary] = None
+
+    def compose(self) -> ComposeResult:  # type: ignore[override]
+        yield Header(show_clock=True)
+        yield Footer()
+        yield PrimaryLayout()
+
+    async def on_mount(self) -> None:
+        await self._refresh_projects()
+        self.set_interval(1.5, self._refresh_queue)
+
+    async def action_refresh_projects(self) -> None:
+        await self._refresh_projects()
+
+    async def _refresh_projects(self) -> None:
+        project_list = self.query_one(ProjectList)
+        summaries = self.session.discover_projects()
+        project_list.set_projects(summaries)
+        summary_view = self.query_one(ProjectSummaryView)
+        if summaries:
+            summary_view.show_project(summaries[0])
+            project_list.index = 0
+            self._set_active_project(summaries[0])
+        else:
+            summary_view.show_project(None)
+            self._set_active_project(None)
+
+    def on_list_view_selected(self, event: ListView.Selected) -> None:
+        if event.list_view.id != "project-list":
+            return
+        summary_view = self.query_one(ProjectSummaryView)
+        project: Optional[ProjectSummary] = None
+        if hasattr(event.item, "data") and isinstance(event.item.data, ProjectSummary):
+            project = event.item.data
+        summary_view.show_project(project)
+        self._set_active_project(project)
+
+    def _set_active_project(self, project: Optional[ProjectSummary]) -> None:
+        self._active_project = project
+        self.session.bind_results_root(project)
+        queue = self.query_one(AnalysisQueueView)
+        manager = self.session.analysis_manager if project and self.session.pending_jobs() else None
+        queue.refresh_from_manager(manager)
+
+    def _refresh_queue(self) -> None:
+        queue = self.query_one(AnalysisQueueView)
+        manager = self.session.analysis_manager if self.session.pending_jobs() else None
+        queue.refresh_from_manager(manager)
+
+    async def on_shutdown_request(self, event: events.ShutdownRequest) -> None:  # pragma: no cover - UI lifecycle
+        self.session.shutdown()
+        await super().on_shutdown_request(event)

--- a/streamline/tui/app.tcss
+++ b/streamline/tui/app.tcss
@@ -1,0 +1,38 @@
+#workspace {
+    height: 1fr;
+}
+
+#sidebar {
+    width: 32;
+    border: tall $secondary;
+    padding: 1 1;
+    background: $panel;
+}
+
+#main {
+    border: tall $surface;
+    padding: 1 2;
+    background: $background 10%;
+    gap: 1;
+}
+
+.section-title {
+    text-style: bold;
+    padding-bottom: 1;
+}
+
+ProjectList {
+    height: 1fr;
+    border: round $primary;
+}
+
+ProjectSummaryView {
+    border: round $surface;
+    min-height: 10;
+    padding: 1;
+}
+
+AnalysisQueueView {
+    height: 1fr;
+    border: round $surface;
+}

--- a/streamline/tui/session.py
+++ b/streamline/tui/session.py
@@ -1,0 +1,114 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+from pathlib import Path
+from typing import Dict, List, Optional
+
+from ..analysis import AnalysisManager
+from ..core import StreamlineError, get_logger
+from ..io.fs import load_project_def
+from ..io.results_index import load_result_entries
+
+
+@dataclass(slots=True)
+class ProjectSummary:
+    project_id: str
+    path: Path
+    description: str
+    has_model: bool
+    last_run: Optional[datetime]
+
+
+class StreamlineSession:
+    """Owns shared state for the Textual application."""
+
+    def __init__(self, projects_root: Path, *, open_gui: bool = False) -> None:
+        self.logger = get_logger(__name__)
+        self.projects_root = projects_root
+        self.projects_root.mkdir(parents=True, exist_ok=True)
+        self._analysis_manager: Optional[AnalysisManager] = None
+        self._open_gui = open_gui
+
+    @property
+    def analysis_manager(self) -> AnalysisManager:
+        if self._analysis_manager is None:
+            self._analysis_manager = AnalysisManager(
+                results_root=None,
+                open_gui=self._open_gui,
+            )
+        return self._analysis_manager
+
+    def discover_projects(self) -> List[ProjectSummary]:
+        summaries: List[ProjectSummary] = []
+        for candidate in sorted(self.projects_root.iterdir()):
+            if not candidate.is_dir():
+                continue
+            try:
+                project_def = load_project_def(candidate)
+            except FileNotFoundError:
+                continue
+            except StreamlineError as exc:
+                self.logger.warning(
+                    "Failed to load project definition", context={"project": str(candidate)}, hint=str(exc)
+                )
+                continue
+            except Exception as exc:  # pragma: no cover - defensive
+                self.logger.warning(
+                    "Unhandled error loading project definition",
+                    context={"project": str(candidate)},
+                    hint=str(exc),
+                )
+                continue
+
+            vsp_path = candidate / f"{candidate.name}.vsp3"
+            last_run = None
+            try:
+                entries = load_result_entries(candidate)
+            except Exception as exc:  # pragma: no cover - defensive
+                self.logger.warning(
+                    "Failed to load project results index",
+                    context={"project_id": project_def.project_id},
+                    hint=str(exc),
+                )
+                entries = []
+            if entries:
+                entries = [e for e in entries if e.manifest and e.manifest.started_utc]
+                if entries:
+                    entries.sort(key=lambda e: e.manifest.started_utc or "", reverse=True)
+                    last = entries[0].manifest.started_utc
+                    if last:
+                        try:
+                            last_run = datetime.fromisoformat(last.replace("Z", ""))
+                        except ValueError:
+                            last_run = None
+
+            summaries.append(
+                ProjectSummary(
+                    project_id=project_def.project_id,
+                    path=candidate,
+                    description=project_def.description or "",
+                    has_model=vsp_path.exists(),
+                    last_run=last_run,
+                )
+            )
+        return summaries
+
+    def pending_jobs(self) -> Dict[str, object]:
+        if self._analysis_manager is None:
+            return {}
+        try:
+            return self._analysis_manager.pending_jobs()
+        except Exception as exc:  # pragma: no cover - defensive logging
+            self.logger.warning("Failed to query pending jobs", hint=str(exc))
+            return {}
+
+    def bind_results_root(self, project: Optional[ProjectSummary]) -> None:
+        if self._analysis_manager is None or project is None:
+            return
+        results_root = project.path / "results"
+        results_root.mkdir(parents=True, exist_ok=True)
+        self._analysis_manager.set_results_root(results_root)
+
+    def shutdown(self) -> None:
+        self._analysis_manager = None

--- a/streamline/tui/widgets.py
+++ b/streamline/tui/widgets.py
@@ -1,0 +1,91 @@
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Iterable, Optional
+
+from textual.app import ComposeResult
+from textual.containers import Container, Horizontal, Vertical
+from textual.reactive import reactive
+from textual.widgets import DataTable, Label, ListItem, ListView, Static
+
+from .session import ProjectSummary
+
+
+class ProjectList(ListView):
+    """List projects discovered on disk."""
+
+    projects: reactive[list[ProjectSummary]] = reactive([], init=False)
+
+    def set_projects(self, projects: Iterable[ProjectSummary]) -> None:
+        self.clear()
+        self.projects = list(projects)
+        if not self.projects:
+            empty = ListItem(Label("No projects found"), id="empty", disabled=True)
+            self.append(empty)
+            self.index = 0
+            return
+        for summary in self.projects:
+            label = Label(summary.project_id)
+            item = ListItem(label, id=summary.project_id, data=summary)
+            self.append(item)
+        self.index = 0
+
+
+class ProjectSummaryView(Static):
+    """Display core details about the active project."""
+
+    project: reactive[Optional[ProjectSummary]] = reactive(None, init=False)
+
+    def show_project(self, project: Optional[ProjectSummary]) -> None:
+        self.project = project
+        if project is None:
+            self.update("Select a project to view details.")
+            return
+        lines = [
+            f"[b]{project.project_id}[/b]",
+            project.description or "No description provided.",
+            "",
+            f"Model file: {'available' if project.has_model else 'missing'}",
+        ]
+        if project.last_run:
+            last = project.last_run.strftime("%Y-%m-%d %H:%M")
+            lines.append(f"Last analysis: {last} UTC")
+        else:
+            lines.append("Last analysis: none recorded")
+        self.update("\n".join(lines))
+
+
+class AnalysisQueueView(DataTable):
+    """Present pending jobs from the AnalysisManager queue."""
+
+    def on_mount(self) -> None:  # pragma: no cover - UI wiring
+        self.add_columns("Job ID", "Analysis", "Status")
+        self.cursor_type = "row"
+
+    def refresh_from_manager(self, manager) -> None:
+        self.clear(columns=False)
+        if manager is None:
+            return
+        try:
+            pending = manager.pending_jobs()
+        except Exception:  # pragma: no cover - defensive UI update
+            return
+        for job_id, state in pending.items():
+            status = state.status
+            analysis = state.job.analysis_key
+            self.add_row(job_id, analysis, status)
+
+
+class PrimaryLayout(Container):
+    """Top-level layout for the Streamline Textual app."""
+
+    def compose(self) -> ComposeResult:  # type: ignore[override]
+        with Horizontal(id="workspace"):
+            with Vertical(id="sidebar"):
+                yield Label("Projects", classes="section-title")
+                yield ProjectList(id="project-list")
+            with Vertical(id="main"):
+                yield Label("Project Overview", classes="section-title")
+                yield ProjectSummaryView(id="project-summary")
+                yield Label("Analysis Queue", classes="section-title")
+                yield AnalysisQueueView(id="analysis-queue")


### PR DESCRIPTION
## Summary
- add an initial Textual `StreamlineApp` with project list, overview, and queue panels
- provide session and widget helpers plus styling to back the new TUI
- expose a `tui` CLI command for launching the interface from `streamline.main`

## Testing
- python -m compileall streamline/tui

------
https://chatgpt.com/codex/tasks/task_e_68e3385da8688323b9e77050ecf450d2