### PR TITLE
Add OpenVSP CompGeom analysis support

### DIFF
--- a/streamline/analysis/manager.py
+++ b/streamline/analysis/manager.py
@@ -23,6 +23,7 @@ from ..io.results_index import (
 )
 from ..vsp.contracts.base import Receipt, Ticket
 from ..vsp.contracts.compute_geometry import ComputeGeometryReceipt
+from ..vsp.contracts.comp_geom import CompGeomReceipt
 from ..vsp.contracts.parasite_drag import ParasiteDragReceipt
 from ..vsp.contracts.stability import StabilityReceipt
 from ..vsp.run_utils import dump_json, prepare_results_dir, relativize
@@ -251,6 +252,10 @@ class AnalysisManager:
             run_compute_geometry,
             _materialize_compute_geometry,
         )
+        from ..vsp.analyses.comp_geom import (
+            run_comp_geom,
+            _materialize_comp_geom,
+        )
         from ..vsp.analyses.parasite_drag import (
             run_parasite_drag,
             _materialize_parasite_drag,
@@ -267,6 +272,14 @@ class AnalysisManager:
             default_dependency_keys={"vsp_model", "configuration"},
             receipt_model=ComputeGeometryReceipt,
             description="Pre-compute VSPAERO geometry inputs",
+        )
+        self.register_analysis(
+            "comp_geom",
+            run_comp_geom,
+            materializer=_materialize_comp_geom,
+            default_dependency_keys={"vsp_model", "configuration"},
+            receipt_model=CompGeomReceipt,
+            description="Run OpenVSP CompGeom surface intersection analysis",
         )
         self.register_analysis(
             "vspaero_stability",

--- a/streamline/vsp/analyses/__init__.py
+++ b/streamline/vsp/analyses/__init__.py
@@ -1,3 +1,4 @@
 from .compute_geometry import run_compute_geometry
 from .parasite_drag import run_parasite_drag
 from .stability import run_stability
+from .comp_geom import run_comp_geom

--- a/streamline/vsp/analyses/_set_utils.py
+++ b/streamline/vsp/analyses/_set_utils.py
@@ -1,0 +1,57 @@
+# streamline/vsp/analyses/_set_utils.py
+from __future__ import annotations
+
+from typing import Optional
+
+from ..configure import AppliedConfiguration
+from ..sets import choose_populated_set
+
+
+def resolve_set_index(vsp, ticket, applied_cfg: Optional[AppliedConfiguration]):
+    """Resolve the set index to analyze for a ticket."""
+    if getattr(ticket, "set_index", None) is not None:
+        try:
+            return int(getattr(ticket, "set_index"))
+        except Exception:
+            pass
+    if applied_cfg and applied_cfg.geom_set_index is not None:
+        try:
+            return int(applied_cfg.geom_set_index)
+        except Exception:
+            pass
+
+    candidates = []
+    ticket_name = getattr(ticket, "set_name", None)
+    if ticket_name:
+        candidates.append(ticket_name)
+    if applied_cfg and applied_cfg.geom_set_name:
+        candidates.append(applied_cfg.geom_set_name)
+
+    try:
+        mapping = {i: vsp.GetSetName(i) for i in range(vsp.GetNumSets())}
+    except Exception:
+        mapping = {}
+
+    for candidate in candidates:
+        if not candidate:
+            continue
+        for idx, name in mapping.items():
+            if name and name.lower() == str(candidate).lower():
+                return idx
+
+    try:
+        return choose_populated_set(vsp)
+    except Exception:
+        return None
+
+
+def resolve_set_name(vsp, set_idx: Optional[int], applied_cfg: Optional[AppliedConfiguration]):
+    """Resolve the friendly set name associated with ``set_idx``."""
+    if set_idx is None:
+        return applied_cfg.geom_set_name if applied_cfg else None
+    if applied_cfg and applied_cfg.geom_set_index == set_idx and applied_cfg.geom_set_name:
+        return applied_cfg.geom_set_name
+    try:
+        return vsp.GetSetName(int(set_idx))
+    except Exception:
+        return applied_cfg.geom_set_name if applied_cfg else None

--- a/streamline/vsp/analyses/comp_geom.py
+++ b/streamline/vsp/analyses/comp_geom.py
@@ -1,0 +1,258 @@
+# streamline/vsp/analyses/comp_geom.py
+from __future__ import annotations
+
+import json
+from datetime import datetime
+from pathlib import Path
+from typing import Any, Dict, Optional, TYPE_CHECKING
+
+from ...core.schema import Configuration, RunManifest
+from ...io.results_index import ResultIndexEntry, append_result_entry
+from ..configure import AppliedConfiguration, apply_configuration
+from ..run_utils import dump_json, prepare_results_dir, relativize
+from ..util import as_list, apply_udp_overrides
+from ..results import dump_available, get as get_result
+from ..contracts.comp_geom import CompGeomTicket, CompGeomPayload, CompGeomReceipt
+from ._set_utils import resolve_set_index, resolve_set_name
+
+if TYPE_CHECKING:
+    from ...analysis.manager import AnalysisJob, AnalysisManager
+
+
+def _normalize_export_mask(value: Optional[int | list[int]]) -> Optional[int]:
+    if value is None:
+        return None
+    if isinstance(value, int):
+        return int(value)
+    mask = 0
+    for item in value:
+        try:
+            mask |= int(item)
+        except Exception:
+            continue
+    return mask if mask else None
+
+
+def _set_int_input(vsp, analysis: str, name: str, value: int) -> bool:
+    try:
+        vsp.SetIntAnalysisInput(analysis, name, as_list(int(value)))
+        return True
+    except Exception:
+        return False
+
+
+def _set_bool_input(vsp, analysis: str, name: str, flag: Optional[bool]) -> None:
+    if flag is None:
+        return
+    _set_int_input(vsp, analysis, name, 1 if flag else 0)
+
+
+def _coerce_value(value: Any) -> Any:
+    if value is None:
+        return None
+    if isinstance(value, (str, int, float)):
+        return value
+    if isinstance(value, dict):
+        return {str(k): _coerce_value(v) for k, v in value.items()}
+    if isinstance(value, (list, tuple)):
+        return [_coerce_value(v) for v in value]
+    try:
+        return float(value)
+    except Exception:
+        return str(value)
+
+
+def _extract_scalar(value: Any) -> Optional[float]:
+    if isinstance(value, (int, float)):
+        return float(value)
+    if isinstance(value, list) and len(value) == 1:
+        elem = value[0]
+        if isinstance(elem, (int, float)):
+            return float(elem)
+    return None
+
+
+def run_comp_geom(
+    vsp,
+    ticket: CompGeomTicket,
+    configuration: Optional[Configuration] = None,
+    applied_configuration: Optional[AppliedConfiguration] = None,
+) -> CompGeomPayload:
+    if configuration is not None and applied_configuration is not None:
+        raise ValueError("Provide either configuration or applied_configuration, not both.")
+
+    applied_cfg = applied_configuration
+    if configuration is not None:
+        applied_cfg = apply_configuration(
+            vsp,
+            configuration,
+            fallback_set_index=ticket.set_index,
+            fallback_set_name=ticket.set_name,
+        )
+
+    set_idx = resolve_set_index(vsp, ticket, applied_cfg)
+    set_name = resolve_set_name(vsp, set_idx, applied_cfg)
+
+    parm_overrides: Dict[str, float] = {}
+    if applied_cfg and applied_cfg.parm_overrides:
+        parm_overrides.update(applied_cfg.parm_overrides)
+    if ticket.udp_overrides:
+        parm_overrides.update(ticket.udp_overrides)
+    if ticket.runtime_overrides:
+        parm_overrides.update(ticket.runtime_overrides)
+    if parm_overrides:
+        apply_udp_overrides(vsp, parm_overrides)
+
+    analysis = "CompGeom"
+    vsp.SetAnalysisInputDefaults(analysis)
+
+    if set_idx is not None:
+        if not _set_int_input(vsp, analysis, "Set", int(set_idx)):
+            _set_int_input(vsp, analysis, "GeomSet", int(set_idx))
+
+    _set_bool_input(vsp, analysis, "HalfMeshFlag", ticket.half_mesh_flag)
+
+    file_export_mask = _normalize_export_mask(ticket.file_export_types)
+    if file_export_mask is not None:
+        for name in ("FileExportFlags", "FileExportTypes", "ExportFileFlag"):
+            if _set_int_input(vsp, analysis, name, file_export_mask):
+                break
+
+    if ticket.write_csv_flag is not None:
+        _set_bool_input(vsp, analysis, "WriteCSVFlag", ticket.write_csv_flag)
+
+    for flag_name, enabled in (ticket.write_flags or {}).items():
+        if isinstance(enabled, bool):
+            _set_bool_input(vsp, analysis, flag_name, enabled)
+
+    vsp.Update()
+    results_id = vsp.ExecAnalysis(analysis)
+
+    available = dump_available(vsp, results_id)
+    results_data: Dict[str, Any] = {}
+    summary: Dict[str, float] = {}
+    mesh_geom_ids: list[str] = []
+
+    for name in available:
+        try:
+            raw = get_result(vsp, results_id, name)
+        except Exception:
+            continue
+        coerced = _coerce_value(raw)
+        results_data[name] = coerced
+        scalar = _extract_scalar(coerced)
+        if scalar is not None:
+            summary[name] = scalar
+        if name == "Mesh_GeomID":
+            if isinstance(coerced, list):
+                mesh_geom_ids = [str(item) for item in coerced if isinstance(item, str)]
+
+    if ticket.cleanup_mesh_geoms and mesh_geom_ids:
+        try:
+            vsp.DeleteGeomVec(mesh_geom_ids)
+        except Exception:
+            pass
+
+    try:
+        vsp.ClearResults(results_id)
+    except Exception:
+        pass
+
+    applied_var_presets = applied_cfg.applied_var_presets if applied_cfg else []
+
+    return CompGeomPayload(
+        analysis_name=analysis,
+        set_index=set_idx,
+        set_name=set_name,
+        half_mesh_flag=ticket.half_mesh_flag,
+        write_csv_flag=ticket.write_csv_flag,
+        file_export_mask=file_export_mask,
+        results_available=available,
+        summary=summary,
+        results_data=results_data,
+        mesh_geom_ids=mesh_geom_ids,
+        applied_var_presets=list(applied_var_presets),
+        parm_overrides=dict(parm_overrides),
+    )
+
+
+def _materialize_comp_geom(
+    manager: "AnalysisManager",
+    job: "AnalysisJob",
+    ticket_sha: str,
+    payload: CompGeomPayload,
+    started: datetime,
+    ended: datetime,
+) -> CompGeomReceipt:
+    if not isinstance(payload, CompGeomPayload):
+        raise TypeError(f"Expected CompGeomPayload, got {type(payload).__name__}")
+
+    results_root = manager.results_root
+    artifacts: Dict[str, str] = {}
+    artifact_dir_rel: Optional[str] = None
+    artifact_dir_path: Optional[Path] = None
+
+    settings: Dict[str, Any] = {
+        "analysis": payload.analysis_name,
+        "set_index": payload.set_index,
+        "set_name": payload.set_name,
+        "half_mesh_flag": payload.half_mesh_flag,
+        "write_csv_flag": payload.write_csv_flag,
+        "file_export_mask": payload.file_export_mask,
+        "applied_var_presets": payload.applied_var_presets,
+        "parm_overrides": payload.parm_overrides,
+    }
+
+    if results_root is not None:
+        run_dir = prepare_results_dir(results_root, job.analysis_key, ticket_sha, started)
+        artifact_dir_path = run_dir
+        artifact_dir_rel = relativize(run_dir, results_root)
+
+        ticket_payload = json.loads(job.ticket.model_dump_json(exclude_none=True, exclude_defaults=False))
+        dump_json(run_dir / "ticket.json", ticket_payload)
+        artifacts["ticket_json"] = relativize(run_dir / "ticket.json", results_root)
+
+        dump_json(run_dir / "settings.json", settings)
+        artifacts["settings_json"] = relativize(run_dir / "settings.json", results_root)
+
+        results_blob = {
+            "available": payload.results_available,
+            "summary": payload.summary,
+            "data": payload.results_data,
+        }
+        dump_json(run_dir / "results.json", results_blob)
+        artifacts["results_json"] = relativize(run_dir / "results.json", results_root)
+
+    manifest = RunManifest(
+        tool_versions=manager.versions,
+        inputs_sha256=ticket_sha,
+        started_utc=started.isoformat(timespec="seconds") + "Z",
+        ended_utc=ended.isoformat(timespec="seconds") + "Z",
+        source_paths=[artifact_dir_rel] if artifact_dir_rel is not None else [],
+    )
+
+    if results_root is not None and artifact_dir_path is not None:
+        manifest_path = artifact_dir_path / "run_manifest.json"
+        dump_json(manifest_path, manifest.model_dump())
+        artifacts["run_manifest_json"] = relativize(manifest_path, results_root)
+
+        append_result_entry(
+            results_root.parent,
+            ResultIndexEntry(
+                analysis=job.analysis_key,
+                ticket_sha256=ticket_sha,
+                artifact_dir=artifact_dir_rel,
+                summary=dict(sorted(payload.summary.items())),
+                manifest=manifest,
+            ),
+        )
+
+    return CompGeomReceipt(
+        run_manifest=manifest,
+        ticket_sha256=ticket_sha,
+        artifact_dir=artifact_dir_rel,
+        artifacts=artifacts,
+        settings=settings,
+        summary=dict(payload.summary),
+        available_results=dict(payload.results_available),
+    )

--- a/streamline/vsp/analyses/compute_geometry.py
+++ b/streamline/vsp/analyses/compute_geometry.py
@@ -9,7 +9,6 @@ from typing import Dict, Optional, TYPE_CHECKING
 from ...core.schema import Configuration, RunManifest
 from ...io.results_index import ResultIndexEntry, append_result_entry
 from ..configure import AppliedConfiguration, apply_configuration
-from ..sets import choose_populated_set
 from ..util import as_list, apply_udp_overrides
 from ..contracts.compute_geometry import (
     ComputeGeometryTicket,
@@ -17,58 +16,10 @@ from ..contracts.compute_geometry import (
     ComputeGeometryReceipt,
 )
 from ..run_utils import dump_json, prepare_results_dir, relativize
+from ._set_utils import resolve_set_index, resolve_set_name
 
 if TYPE_CHECKING:
     from ...analysis.manager import AnalysisJob, AnalysisManager
-
-
-def _resolve_set_index(
-    vsp,
-    ticket: ComputeGeometryTicket,
-    applied_cfg: Optional[AppliedConfiguration],
-) -> Optional[int]:
-    if ticket.set_index is not None:
-        return int(ticket.set_index)
-    if applied_cfg and applied_cfg.geom_set_index is not None:
-        return int(applied_cfg.geom_set_index)
-
-    candidates = []
-    if ticket.set_name:
-        candidates.append(ticket.set_name)
-    if applied_cfg and applied_cfg.geom_set_name:
-        candidates.append(applied_cfg.geom_set_name)
-
-    try:
-        mapping = {i: vsp.GetSetName(i) for i in range(vsp.GetNumSets())}
-    except Exception:
-        mapping = {}
-
-    for candidate in candidates:
-        if not candidate:
-            continue
-        for idx, name in mapping.items():
-            if name and name.lower() == candidate.lower():
-                return idx
-
-    try:
-        return choose_populated_set(vsp)
-    except Exception:
-        return None
-
-
-def _resolve_set_name(
-    vsp,
-    set_idx: Optional[int],
-    applied_cfg: Optional[AppliedConfiguration],
-) -> Optional[str]:
-    if set_idx is None:
-        return applied_cfg.geom_set_name if applied_cfg else None
-    if applied_cfg and applied_cfg.geom_set_index == set_idx and applied_cfg.geom_set_name:
-        return applied_cfg.geom_set_name
-    try:
-        return vsp.GetSetName(int(set_idx))
-    except Exception:
-        return applied_cfg.geom_set_name if applied_cfg else None
 
 
 def run_compute_geometry(
@@ -91,8 +42,8 @@ def run_compute_geometry(
         else (applied_cfg.use_mode_flag if applied_cfg and applied_cfg.use_mode_flag is not None else None)
     )
 
-    set_idx = _resolve_set_index(vsp, ticket, applied_cfg)
-    set_name = _resolve_set_name(vsp, set_idx, applied_cfg)
+    set_idx = resolve_set_index(vsp, ticket, applied_cfg)
+    set_name = resolve_set_name(vsp, set_idx, applied_cfg)
 
     analysis = "VSPAEROComputeGeometry"
     vsp.SetAnalysisInputDefaults(analysis)

--- a/streamline/vsp/contracts/__init__.py
+++ b/streamline/vsp/contracts/__init__.py
@@ -1,3 +1,4 @@
 from .stability import StabilityTicket, StabilityReceipt
 from .compute_geometry import ComputeGeometryTicket, ComputeGeometryReceipt
 from .parasite_drag import ParasiteDragTicket, ParasiteDragReceipt
+from .comp_geom import CompGeomTicket, CompGeomReceipt

--- a/streamline/vsp/contracts/comp_geom.py
+++ b/streamline/vsp/contracts/comp_geom.py
@@ -1,0 +1,41 @@
+# streamline/vsp/contracts/comp_geom.py
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Optional, Tuple
+
+from pydantic import Field
+
+from .base import Ticket, Receipt
+
+
+class CompGeomTicket(Ticket):
+    """Inputs for running the OpenVSP ``CompGeom`` analysis."""
+
+    half_mesh_flag: Optional[bool] = None
+    write_csv_flag: Optional[bool] = None
+    file_export_types: Optional[int | List[int]] = None
+    write_flags: Dict[str, bool] = Field(default_factory=dict)
+    cleanup_mesh_geoms: bool = True
+
+
+@dataclass
+class CompGeomPayload:
+    analysis_name: str
+    set_index: Optional[int]
+    set_name: Optional[str]
+    half_mesh_flag: Optional[bool]
+    write_csv_flag: Optional[bool]
+    file_export_mask: Optional[int]
+    results_available: Dict[str, str] = field(default_factory=dict)
+    summary: Dict[str, float] = field(default_factory=dict)
+    results_data: Dict[str, Any] = field(default_factory=dict)
+    mesh_geom_ids: List[str] = field(default_factory=list)
+    applied_var_presets: List[Tuple[str, str]] = field(default_factory=list)
+    parm_overrides: Dict[str, float] = field(default_factory=dict)
+
+
+class CompGeomReceipt(Receipt):
+    settings: Dict[str, Any] = Field(default_factory=dict)
+    summary: Dict[str, float] = Field(default_factory=dict)
+    available_results: Dict[str, str] = Field(default_factory=dict)

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,1 +1,1 @@
-
+from __future__ import annotations

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,8 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))

--- a/tests/vsp/test_comp_geom_analysis.py
+++ b/tests/vsp/test_comp_geom_analysis.py
@@ -1,0 +1,142 @@
+from __future__ import annotations
+
+from datetime import datetime, timedelta
+from types import SimpleNamespace
+
+import pytest
+
+from streamline.vsp.analyses.comp_geom import run_comp_geom, _materialize_comp_geom
+from streamline.vsp.contracts.comp_geom import CompGeomTicket, CompGeomPayload
+from streamline.analysis.manager import AnalysisJob
+
+
+class FakeVSP:
+    def __init__(self) -> None:
+        self.int_inputs: dict[tuple[str, str], list[int]] = {}
+        self.updated = False
+        self.deleted_ids: list[str] = []
+        self.cleared_results: list[str] = []
+
+    def SetAnalysisInputDefaults(self, analysis: str) -> None:
+        self.defaults = analysis
+
+    def SetIntAnalysisInput(self, analysis: str, name: str, values):
+        if analysis != "CompGeom":
+            raise RuntimeError("unexpected analysis")
+        if name == "FileExportFlags" and values[0] < 0:
+            raise RuntimeError("bad value")
+        self.int_inputs[(analysis, name)] = list(values)
+
+    def Update(self) -> None:
+        self.updated = True
+
+    def ExecAnalysis(self, analysis: str) -> str:
+        assert analysis == "CompGeom"
+        return "results-id"
+
+    def GetAllDataNames(self, results_id: str):
+        assert results_id == "results-id"
+        return ["Wet_Area", "Mesh_GeomID", "Component_Wet_Area"]
+
+    def GetResultsType(self, results_id: str, name: str) -> str:
+        if name == "Mesh_GeomID":
+            return "RES_DATA_STRING"
+        return "RES_DATA_DOUBLE"
+
+    def GetDoubleResults(self, results_id: str, name: str):
+        if name == "Wet_Area":
+            return [12.5]
+        if name == "Component_Wet_Area":
+            return [7.5, 5.0]
+        return []
+
+    def GetStringResults(self, results_id: str, name: str):
+        if name == "Mesh_GeomID":
+            return ["mesh_1"]
+        return []
+
+    def DeleteGeomVec(self, geom_ids):
+        self.deleted_ids.extend(list(geom_ids))
+
+    def ClearResults(self, results_id: str):
+        self.cleared_results.append(results_id)
+
+    def GetSetName(self, idx: int) -> str:
+        return {2: "MySet"}.get(idx, "")
+
+    def GetNumSets(self) -> int:
+        return 3
+
+
+@pytest.fixture()
+def fake_manager(tmp_path):
+    project_root = tmp_path / "project"
+    results_root = project_root / "results"
+    results_root.mkdir(parents=True, exist_ok=True)
+    manager = SimpleNamespace(results_root=results_root, versions={"openvsp_api": "test"})
+    return manager
+
+
+def test_run_comp_geom_collects_results_and_sets_inputs():
+    vsp = FakeVSP()
+    ticket = CompGeomTicket(set_index=2, half_mesh_flag=True, write_csv_flag=False, file_export_types=[1, 2])
+
+    payload = run_comp_geom(vsp, ticket)
+
+    assert isinstance(payload, CompGeomPayload)
+    assert vsp.int_inputs[("CompGeom", "Set")] == [2]
+    assert vsp.int_inputs[("CompGeom", "HalfMeshFlag")] == [1]
+    assert vsp.int_inputs[("CompGeom", "WriteCSVFlag")] == [0]
+    assert vsp.int_inputs[("CompGeom", "FileExportFlags")] == [3]
+    assert payload.summary["Wet_Area"] == pytest.approx(12.5)
+    assert payload.results_data["Component_Wet_Area"] == pytest.approx([7.5, 5.0])
+    assert vsp.deleted_ids == ["mesh_1"]
+    assert vsp.cleared_results == ["results-id"]
+
+
+def test_materialize_comp_geom_writes_artifacts(fake_manager):
+    ticket = CompGeomTicket(set_index=1, half_mesh_flag=False)
+    payload = CompGeomPayload(
+        analysis_name="CompGeom",
+        set_index=1,
+        set_name="All",
+        half_mesh_flag=False,
+        write_csv_flag=True,
+        file_export_mask=4,
+        results_available={"Wet_Area": "RES_DATA_DOUBLE"},
+        summary={"Wet_Area": 10.0},
+        results_data={"Wet_Area": [10.0]},
+        mesh_geom_ids=["mesh_1"],
+        applied_var_presets=[],
+        parm_overrides={},
+    )
+    started = datetime.utcnow()
+    ended = started + timedelta(seconds=5)
+    job = AnalysisJob(
+        job_id="job",
+        analysis_key="comp_geom",
+        ticket=ticket,
+        context_extras={},
+        runtime_kwargs={},
+        dependency_keys=set(),
+        wait_for=set(),
+        priority=0,
+    )
+    ticket_sha = ticket.sha256()
+
+    receipt = _materialize_comp_geom(fake_manager, job, ticket_sha, payload, started, ended)
+
+    run_dirs = list(fake_manager.results_root.glob("comp_geom/*"))
+    assert run_dirs, "run directory not created"
+    run_dir = run_dirs[0]
+    assert (run_dir / "ticket.json").exists()
+    assert (run_dir / "settings.json").exists()
+    assert (run_dir / "results.json").exists()
+    manifest_path = run_dir / "run_manifest.json"
+    assert manifest_path.exists()
+
+    index_path = fake_manager.results_root.parent / "results" / "index.json"
+    assert index_path.exists()
+
+    assert receipt.summary == {"Wet_Area": 10.0}
+    assert receipt.available_results == {"Wet_Area": "RES_DATA_DOUBLE"}


### PR DESCRIPTION
## Summary
- add a CompGeom analysis contract, runner, and result materializer for OpenVSP
- share set resolution helpers across analyses and register the new comp_geom analysis key
- add pytest coverage and ensure tests can import the project package

## Testing
- pytest tests/vsp/test_comp_geom_analysis.py

------
https://chatgpt.com/codex/tasks/task_e_68e48ef01e1c8323a65842f15a514cc2