### PR TITLE
Ensure CI uses OpenVSP bindings

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: "3.12"
+          python-version: "3.11"
 
       - name: Install dependencies
         run: |

--- a/streamline/vsp/test_factory.py
+++ b/streamline/vsp/test_factory.py
@@ -10,6 +10,7 @@ from ..core.logging import get_logger
 
 class _FakeOpenVSP:
     def __init__(self) -> None:
+        self.__fake_vsp__ = True
         self.ClearVSPModel()
 
     def ClearVSPModel(self) -> None:
@@ -71,17 +72,19 @@ def import_openvsp() -> Optional[Any]:
     try:
         import openvsp as vsp  # type: ignore
         if hasattr(vsp, "ClearVSPModel"):
+            setattr(vsp, "__fake_vsp__", False)
             return vsp
-    except ModuleNotFoundError:
+    except (ModuleNotFoundError, ImportError):
         vsp = None
 
     if vsp is None:
         try:
             import openvsp.openvsp as vsp  # type: ignore
-        except ModuleNotFoundError:
+        except (ModuleNotFoundError, ImportError):
             vsp = None
 
     if vsp is not None and hasattr(vsp, "ClearVSPModel"):
+        setattr(vsp, "__fake_vsp__", False)
         return vsp
 
     return _FAKE_VSP

--- a/tests/vsp/test_geometry_factory.py
+++ b/tests/vsp/test_geometry_factory.py
@@ -1,18 +1,29 @@
 from __future__ import annotations
 
+import os
 from pathlib import Path
+
+import pytest
 
 from streamline.vsp.test_factory import build_basic_transport, import_openvsp
 
 
 def test_import_openvsp_returns_module():
     vsp_module = import_openvsp()
+    if getattr(vsp_module, "__fake_vsp__", False):
+        if os.environ.get("CI"):
+            pytest.fail("OpenVSP Python module was not available in CI")
+        pytest.skip("OpenVSP Python module is not available")
     assert vsp_module is not None
     assert hasattr(vsp_module, "ClearVSPModel")
 
 
 def test_build_basic_transport(tmp_path: Path):
     vsp_module = import_openvsp()
+    if getattr(vsp_module, "__fake_vsp__", False):
+        if os.environ.get("CI"):
+            pytest.fail("OpenVSP Python module was not available in CI")
+        pytest.skip("OpenVSP Python module is not available")
     model_path = tmp_path / "ci_model.vsp3"
     results = build_basic_transport(output_path=model_path)
 


### PR DESCRIPTION
## Summary
- mark the OpenVSP stub so tests can detect whether the real bindings loaded
- require the real OpenVSP module in CI while skipping tests locally when it is unavailable
- align the GitHub Actions runner with Python 3.11 so the bundled OpenVSP bindings can load

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e4930110e8832387cfd8572f53ebc1