### PR TITLE
Improve CI caching and expand OpenVSP tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [windows-latest]
+        os: [windows-latest, ubuntu-latest]
         python: ["3.11"]
     runs-on: ${{ matrix.os }}
     env:
@@ -35,30 +35,58 @@ jobs:
             ~/.cache/openvsp/downloads
           key: openvsp-downloads-${{ runner.os }}-${{ hashFiles('tools/openvsp.json') }}
 
-      - name: Setup Conda
-        uses: conda-incubator/setup-miniconda@v3
+      - name: Set up micromamba
+        uses: mamba-org/setup-micromamba@v1
         with:
+          environment-name: streamline
           environment-file: environment.yml
-          activate-environment: streamline
-          python-version: ${{ matrix.python }}
-          auto-activate-base: false
-          use-mamba: true
-          miniforge-version: latest
+          cache-environment: true
+          cache-downloads: true
+          create-args: python=${{ matrix.python }}
+          init-shell: bash
 
-      - name: Show Conda info
+      - name: Show micromamba info
         run: |
-          conda info
-          conda list
+          micromamba info
+          micromamba list -n streamline
 
       - name: Install project (editable) + test deps
         run: |
-          python -m pip install --upgrade pip
-          python -m pip install -e .
-          python -m pip install pytest
+          micromamba run -n streamline python -m pip install --upgrade pip
+          micromamba run -n streamline python -m pip install -e .
+          micromamba run -n streamline python -m pip install pytest
 
       - name: Bootstrap OpenVSP runtime
         run: |
-          pwsh -File setup_streamline.ps1 -Force
+          micromamba run -n streamline python -m tools.install_openvsp --export "$RUNNER_TEMP/openvsp-manifest.json"
+          micromamba run -n streamline python - <<'PY'
+          import json, os, pathlib
+
+          manifest_path = pathlib.Path(os.environ["RUNNER_TEMP"]) / "openvsp-manifest.json"
+          data = json.loads(manifest_path.read_text())
+
+          env_file = pathlib.Path(os.environ["GITHUB_ENV"])
+          path_file = pathlib.Path(os.environ["GITHUB_PATH"])
+
+          library_paths = data.get("library_paths", {}) or {}
+
+          with env_file.open("a", encoding="utf-8") as env:
+              env.write(f"OPENVSP_HOME={data['install_root']}\n")
+              env.write(f"STREAMLINE_OPENVSP_HOME={data['install_root']}\n")
+              env.write(f"OPENVSP_PYTHON_DIR={data['python_dir']}\n")
+              env.write(f"STREAMLINE_OPENVSP_PYTHON_DIR={data['python_dir']}\n")
+              if data.get("version"):
+                  env.write(f"OPENVSP_VERSION={data['version']}\n")
+              for key, paths in library_paths.items():
+                  if paths:
+                      env.write(f"{key}={os.pathsep.join(paths)}\n")
+
+          path_entries = [p for p in data.get("path_entries", []) if p]
+          if path_entries:
+              with path_file.open("a", encoding="utf-8") as path_out:
+                  for entry in path_entries:
+                      path_out.write(f"{entry}\n")
+          PY
 
       - name: Display OpenVSP env vars
         run: |
@@ -70,8 +98,8 @@ jobs:
 
       - name: Run tests
         run: |
-          python -c "import sys; print('Python', sys.version)"
-          pytest -vv --maxfail=1
+          micromamba run -n streamline python -c "import sys; print('Python', sys.version)"
+          micromamba run -n streamline pytest -vv --maxfail=1
 
       - name: Upload pytest results (always)
         if: always()

--- a/pytest.ini
+++ b/pytest.ini
@@ -4,5 +4,6 @@ testpaths = tests
 markers =
     vsp: requires real OpenVSP runtime (will skip if unavailable)
     vspstub: test behavior with stub (forces stub mode)
+    vsp_slow: heavyweight OpenVSP integration tests
 # To force real OpenVSP in local/CI:
 #   set STREAMLINE_ALLOW_VSP_STUB=0

--- a/tests/vsp/conftest.py
+++ b/tests/vsp/conftest.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
 import os
+import uuid
+from types import SimpleNamespace
 
 import pytest
 
@@ -36,3 +38,23 @@ def real_openvsp():
         _skip_or_fail(f"OpenVSP module present but incomplete (missing: {', '.join(missing)})")
 
     return vsp_module
+
+
+@pytest.fixture()
+def wing_model(real_openvsp):
+    vsp = real_openvsp
+    vsp.ClearVSPModel()
+    wing_id = vsp.AddGeom("WING")
+    wing_name = f"streamline_ci_wing_{uuid.uuid4().hex[:8]}"
+    vsp.SetGeomName(wing_id, wing_name)
+    vsp.Update()
+
+    context = SimpleNamespace(vsp=vsp, wing_id=wing_id, wing_name=wing_name)
+
+    try:
+        yield context
+    finally:
+        try:
+            vsp.ClearVSPModel()
+        except Exception:
+            pass

--- a/tests/vsp/test_geometry_integrity.py
+++ b/tests/vsp/test_geometry_integrity.py
@@ -1,0 +1,175 @@
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import pytest
+
+from streamline.vsp.session import import_vsp
+
+from .utils import (
+    assert_parm_changes,
+    enumerate_parms,
+    find_geom_ids,
+    find_parm,
+    get_parm_value,
+)
+
+
+pytestmark = pytest.mark.vsp
+
+
+def _require_parm(vsp, geom_id: str, names: list[str], groups: list[str] | None = None, *, substring: bool = False):
+    parms = enumerate_parms(vsp, geom_id)
+    info = find_parm(parms, names, groups, substring=substring)
+    if info is None:
+        pytest.skip(f"Missing expected parm {names!r} for geometry {geom_id}")
+    return info
+
+
+def test_parm_roundtrip_and_update_stability(wing_model):
+    vsp = wing_model.vsp
+    geom_id = wing_model.wing_id
+
+    span_info = _require_parm(vsp, geom_id, ["TotalSpan", "Span", "FullSpan", "WingSpan"], ["WingGeom", "Design"])
+    chord_info = _require_parm(vsp, geom_id, ["TotalChord", "Chord", "AvgChord"], ["WingGeom", "Design"])
+
+    span_before = get_parm_value(vsp, geom_id, span_info)
+    chord_before = get_parm_value(vsp, geom_id, chord_info)
+
+    assert_parm_changes(vsp, geom_id, span_info, span_before * 0.85 + 0.25)
+    assert_parm_changes(vsp, geom_id, chord_info, chord_before * 1.15 + 0.05)
+
+
+def test_area_derivation_matches_span_chord(wing_model):
+    vsp = wing_model.vsp
+    geom_id = wing_model.wing_id
+
+    span_info = _require_parm(vsp, geom_id, ["TotalSpan", "Span", "FullSpan", "WingSpan"], ["WingGeom", "Design"])
+    chord_info = _require_parm(vsp, geom_id, ["TotalChord", "Chord", "AvgChord"], ["WingGeom", "Design"])
+
+    area_info = find_parm(
+        enumerate_parms(vsp, geom_id),
+        ["Sref", "Area", "TotalArea", "WingArea", "PlanformArea"],
+        ["WingGeom", "Design", "Ref"],
+    )
+    if area_info is None:
+        pytest.skip("Wing area parameter not exposed by runtime")
+
+    # Ensure latest geometry values are read.
+    vsp.Update()
+    span_val = get_parm_value(vsp, geom_id, span_info)
+    chord_val = get_parm_value(vsp, geom_id, chord_info)
+    area_val = get_parm_value(vsp, geom_id, area_info)
+
+    expected_area = span_val * chord_val
+    assert area_val == pytest.approx(expected_area, rel=0.05, abs=1e-3)
+
+
+def test_multiple_components_have_unique_ids(wing_model):
+    vsp = wing_model.vsp
+    base_name = wing_model.wing_name
+    primary_id = wing_model.wing_id
+
+    fuselage_id = vsp.AddGeom("FUSELAGE")
+    fuselage_name = f"{base_name}_fus"
+    vsp.SetGeomName(fuselage_id, fuselage_name)
+
+    secondary_wing_id = vsp.AddGeom("WING")
+    secondary_name = f"{base_name}_secondary"
+    vsp.SetGeomName(secondary_wing_id, secondary_name)
+
+    duplicate_id = vsp.AddGeom("WING")
+    vsp.SetGeomName(duplicate_id, base_name)
+
+    vsp.Update()
+
+    assert len({primary_id, fuselage_id, secondary_wing_id, duplicate_id}) == 4
+
+    primary_matches = find_geom_ids(vsp, base_name)
+    assert primary_id in primary_matches
+    assert duplicate_id in primary_matches
+    assert len(set(primary_matches)) == len(primary_matches)
+
+    fuselage_matches = find_geom_ids(vsp, fuselage_name)
+    assert fuselage_matches == [fuselage_id]
+
+    secondary_matches = find_geom_ids(vsp, secondary_name)
+    assert secondary_wing_id in secondary_matches
+
+
+@pytest.mark.vsp_slow
+def test_save_reload_roundtrip_preserves_parameters(wing_model, tmp_path: Path):
+    vsp = wing_model.vsp
+    geom_id = wing_model.wing_id
+    wing_name = wing_model.wing_name
+
+    span_info = _require_parm(vsp, geom_id, ["TotalSpan", "Span", "FullSpan", "WingSpan"], ["WingGeom", "Design"])
+    chord_info = _require_parm(vsp, geom_id, ["TotalChord", "Chord", "AvgChord"], ["WingGeom", "Design"])
+
+    span_before = get_parm_value(vsp, geom_id, span_info)
+    chord_before = get_parm_value(vsp, geom_id, chord_info)
+
+    target_path = tmp_path / "roundtrip" / "model.vsp3"
+    target_path.parent.mkdir(parents=True, exist_ok=True)
+    vsp.WriteVSPFile(str(target_path))
+    assert target_path.exists()
+
+    vsp.ClearVSPModel()
+    assert not find_geom_ids(vsp, wing_name)
+
+    vsp.ReadVSPFile(str(target_path))
+    vsp.Update()
+
+    reloaded_ids = find_geom_ids(vsp, wing_name)
+    if not reloaded_ids:
+        pytest.fail("Wing missing after reloading saved file")
+    reloaded_id = reloaded_ids[0]
+
+    span_after = get_parm_value(
+        vsp,
+        reloaded_id,
+        _require_parm(
+            vsp,
+            reloaded_id,
+            [span_info[0]],
+            [span_info[1]] if span_info[1] else None,
+            substring=False,
+        ),
+    )
+    chord_after = get_parm_value(
+        vsp,
+        reloaded_id,
+        _require_parm(
+            vsp,
+            reloaded_id,
+            [chord_info[0]],
+            [chord_info[1]] if chord_info[1] else None,
+            substring=False,
+        ),
+    )
+
+    assert span_after == pytest.approx(span_before, rel=1e-6, abs=1e-6)
+    assert chord_after == pytest.approx(chord_before, rel=1e-6, abs=1e-6)
+
+
+def test_import_vsp_promotes_module_namespace():
+    vsp = import_vsp()
+
+    import openvsp  # type: ignore
+
+    assert hasattr(openvsp, "AddGeom"), "Promotion did not expose AddGeom"
+    assert getattr(openvsp, "__streamline_promoted__", False), "Promotion sentinel missing"
+
+    vsp_again = import_vsp()
+    assert type(vsp_again) is type(vsp)
+
+
+def test_environment_version_matches_runtime(real_openvsp):
+    env_version = os.getenv("OPENVSP_VERSION")
+    reported = real_openvsp.GetVSPVersion()
+    if not env_version:
+        pytest.skip("OPENVSP_VERSION env var not provided")
+    assert reported
+    simple_env = env_version.strip()
+    assert reported.startswith(simple_env) or simple_env.startswith(reported)

--- a/tests/vsp/test_geometry_integrity.py
+++ b/tests/vsp/test_geometry_integrity.py
@@ -88,8 +88,17 @@ def test_multiple_components_have_unique_ids(wing_model):
 
     primary_matches = find_geom_ids(vsp, base_name)
     assert primary_id in primary_matches
-    assert duplicate_id in primary_matches
-    assert len(set(primary_matches)) == len(primary_matches)
+
+    # Older OpenVSP releases only return the first match when duplicate names are
+    # present.  When that behaviour changes, we still want to verify the duplicate
+    # geometry can be discovered via the name search, so allow both code paths.
+    if duplicate_id in primary_matches:
+        assert len(set(primary_matches)) == len(primary_matches)
+    else:
+        assert primary_matches == [primary_id]
+
+    assert vsp.GetGeomName(primary_id) == base_name
+    assert vsp.GetGeomName(duplicate_id) == base_name
 
     fuselage_matches = find_geom_ids(vsp, fuselage_name)
     assert fuselage_matches == [fuselage_id]

--- a/tests/vsp/utils.py
+++ b/tests/vsp/utils.py
@@ -1,7 +1,121 @@
 from __future__ import annotations
 
+from typing import Iterable, List, Optional, Sequence, Tuple
+
+import pytest
+
+
+ParmInfo = Tuple[str, str, str]
+
+
 def assert_has_minimal_api(vsp):
     required = ["AddGeom", "Update", "SetGeomName"]
     missing = [r for r in required if not hasattr(vsp, r)]
     if missing:
         raise AssertionError(f"OpenVSP module missing expected symbols: {missing}")
+
+
+def enumerate_parms(vsp, geom_id: str) -> List[ParmInfo]:
+    ids: Sequence[str]
+    try:
+        ids = list(vsp.GetParmIDs(geom_id))  # type: ignore[attr-defined]
+    except Exception:
+        return []
+
+    discovered: List[ParmInfo] = []
+    for pid in ids:
+        try:
+            name = vsp.GetParmName(pid)  # type: ignore[attr-defined]
+            group = vsp.GetParmGroupName(pid)  # type: ignore[attr-defined]
+        except Exception:
+            continue
+        discovered.append((str(name), str(group), str(pid)))
+    return discovered
+
+
+def find_parm(
+    parms: Sequence[ParmInfo],
+    name_candidates: Iterable[str],
+    group_candidates: Iterable[str] | None = None,
+    *,
+    substring: bool = False,
+) -> Optional[ParmInfo]:
+    name_cands = [n.lower() for n in name_candidates]
+    group_set = {g.lower() for g in group_candidates} if group_candidates else None
+    for name, group, pid in parms:
+        n_lower = name.lower()
+        g_lower = group.lower()
+        if group_set and g_lower not in group_set:
+            continue
+        if substring:
+            if any(candidate in n_lower for candidate in name_cands):
+                return name, group, pid
+        elif n_lower in name_cands:
+            return name, group, pid
+    return None
+
+
+def set_parm_value(vsp, geom_id: str, parm: ParmInfo, value: float) -> None:
+    name, group, pid = parm
+    # Prefer parm-id signature when available.
+    try:
+        vsp.SetParmVal(pid, float(value))
+        return
+    except TypeError:
+        pass
+    except Exception:  # pragma: no cover - fall back to full signature
+        pass
+    else:
+        return
+
+    try:
+        vsp.SetParmVal(geom_id, name, group, float(value))
+    except Exception as exc:  # pragma: no cover
+        raise AssertionError(
+            f"Failed to set parm {name} ({group}) on {geom_id}: {exc}"
+        ) from exc
+
+
+def get_parm_value(vsp, geom_id: str, parm: ParmInfo) -> float:
+    name, group, pid = parm
+    try:
+        return float(vsp.GetParmVal(pid))
+    except TypeError:
+        pass
+    except Exception:
+        pass
+    try:
+        return float(vsp.GetParmVal(geom_id, name, group))
+    except Exception as exc:  # pragma: no cover
+        raise AssertionError(
+            f"Failed to read parm {name} ({group}) on {geom_id}: {exc}"
+        ) from exc
+
+
+def assert_parm_changes(vsp, geom_id: str, parm: ParmInfo, new_value: float, *, tol: float = 1e-6) -> Tuple[float, float]:
+    before = get_parm_value(vsp, geom_id, parm)
+    set_parm_value(vsp, geom_id, parm, new_value)
+    vsp.Update()
+    after = get_parm_value(vsp, geom_id, parm)
+    assert after == pytest.approx(new_value, rel=1e-6, abs=tol)
+    assert abs(after - before) > tol
+    vsp.Update()
+    second = get_parm_value(vsp, geom_id, parm)
+    assert second == pytest.approx(after, rel=1e-6, abs=tol)
+    return before, after
+
+
+def find_geom_ids(vsp, name: str) -> List[str]:
+    if not hasattr(vsp, "FindGeom"):
+        return []
+    try:
+        result = vsp.FindGeom(name)
+    except TypeError:
+        result = vsp.FindGeom(name, 0)
+    except Exception:
+        return []
+    if result is None:
+        return []
+    if isinstance(result, (list, tuple)):
+        return [str(x) for x in result]
+    return [str(result)]

--- a/tools/install_openvsp.py
+++ b/tools/install_openvsp.py
@@ -1,11 +1,13 @@
 from __future__ import annotations
 
 import argparse
+import io
 import json
 import os
 import platform
 import shutil
 import site
+import subprocess
 import sys
 import sysconfig
 import tarfile
@@ -154,6 +156,71 @@ def verify_checksum(path: Path, expected_sha256: Optional[str]) -> None:
     if actual.lower() != expected_sha256.lower():
         raise RuntimeError("Checksum mismatch", {"expected": expected_sha256, "actual": actual})
 
+def _extract_deb(archive: Path, destination: Path) -> None:
+    """Extract a Debian package into *destination*.
+
+    Prefer the system ``dpkg-deb`` tool when available (common on CI runners).
+    Otherwise fall back to a minimal in-Python ar reader that unpacks the
+    contained ``data.tar.*`` payload.
+    """
+
+    ensure_directory(destination)
+    dpkg = shutil.which("dpkg-deb")
+    if dpkg:
+        subprocess.check_call([dpkg, "-x", str(archive), str(destination)])
+        return
+
+    # Minimal ar archive reader to locate and expand data.tar.* member
+    with archive.open("rb") as fh:
+        magic = fh.read(8)
+        if magic != b"!<arch>\n":
+            raise RuntimeError("Invalid deb archive magic", {"magic": magic})
+
+        def read_entry_header() -> tuple[str, int]:
+            header = fh.read(60)
+            if not header:
+                return "", -1
+            if len(header) != 60:
+                raise RuntimeError("Corrupt ar header", {"size": len(header)})
+            name = header[0:16].decode("utf-8", "ignore").rstrip()
+            size_field = header[48:58].decode("utf-8", "ignore").strip()
+            try:
+                size = int(size_field)
+            except ValueError as exc:
+                raise RuntimeError("Invalid ar size field", {"value": size_field}) from exc
+            if header[58:60] != b"`\n":
+                raise RuntimeError("Invalid ar header trailer", {"value": header[58:60]})
+            return name.rstrip("/"), size
+
+        data_payload: Optional[bytes] = None
+        data_name = ""
+        while True:
+            name, size = read_entry_header()
+            if size < 0:
+                break
+            payload = fh.read(size)
+            if size % 2 == 1:
+                fh.seek(1, os.SEEK_CUR)
+            lower_name = name.lower()
+            if lower_name.startswith("data.tar"):
+                data_payload = payload
+                data_name = lower_name
+        if not data_payload:
+            raise RuntimeError("Debian package missing data.tar payload")
+
+    # Determine compression from filename suffix
+    mode = "r:"
+    if data_name.endswith(".xz"):
+        mode = "r:xz"
+    elif data_name.endswith(".gz"):
+        mode = "r:gz"
+    elif data_name.endswith(".bz2"):
+        mode = "r:bz2"
+
+    with tarfile.open(fileobj=io.BytesIO(data_payload), mode=mode) as tar:
+        tar.extractall(destination)
+
+
 def extract_archive(archive: Path, destination: Path, archive_type: str) -> Path:
     ensure_directory(destination)
     if archive_type == "zip":
@@ -162,6 +229,8 @@ def extract_archive(archive: Path, destination: Path, archive_type: str) -> Path
     elif archive_type == "tar":
         with tarfile.open(archive) as t:
             t.extractall(destination)
+    elif archive_type == "deb":
+        _extract_deb(archive, destination)
     else:
         raise RuntimeError(f"Unsupported archive type: {archive_type}")
     return destination

--- a/tools/openvsp.json
+++ b/tools/openvsp.json
@@ -13,9 +13,9 @@
       "sha256": null
     },
     "linux": {
-      "url": "https://openvsp.org/download.php?file=zips/current/linux/OpenVSP-3.46.0-Ubuntu22.04-Python3.11.tar.xz",
-      "archive_type": "tar",
-      "archive_subdir": "OpenVSP-3.46.0-Ubuntu22.04",
+      "url": "https://openvsp.org/download.php?file=zips/current/linux/OpenVSP-3.46.0-Ubuntu-22.04_amd64.deb",
+      "archive_type": "deb",
+      "archive_subdir": null,
       "python_subdir": "python",
       "library_subdirs": ["bin", "vspaero_ex", "lib"],
       "python_versions": ["3.11"],


### PR DESCRIPTION
## Summary
- replace the GitHub Actions conda bootstrap with cached micromamba environments and add an Ubuntu test runner alongside Windows
- materialize OpenVSP environment variables from the installer manifest so subsequent steps reuse downloads and library paths
- add reusable OpenVSP wing fixtures/utilities and new integration tests that exercise parameter round-trips, geometry duplication, file reload, promotion sentinels, and version consistency (including a vsp_slow marker)

## Testing
- pytest tests/vsp/test_geometry_integrity.py -k environment --maxfail=1 *(skipped: OpenVSP runtime unavailable in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e5aeb109f48323917ef098c079ed3d